### PR TITLE
Represent storetheindex v0 finder protocol in schema

### DIFF
--- a/ipld/routing.ipldsch
+++ b/ipld/routing.ipldsch
@@ -4,12 +4,30 @@ type Envelope union {
      | GetP2PProvideResponse "get-p2p-provide-response"
 } representation keyed
 
+type Multihash Bytes
+
 type GetP2PProvideRequest struct {
-     key Bytes
+     Multihashes [Multihash]
 }
 
 type GetP2PProvideResponse struct {
-     providers [Provider]
+     MultihashResults [MultihashResult]
+}
+
+type MultihashResult struct {
+     Multihash Multihash
+     ProviderResults [ProviderResult]
+}
+
+type ProviderResult struct {
+     Metadata Metadata
+     Provider Provider
+}
+
+# XXX: represent as union of known options
+type Metadata struct {
+     ProtocolID Int
+     Data Bytes
 }
 
 type Provider union {
@@ -17,7 +35,8 @@ type Provider union {
 } representation keyed
 
 type Peer struct {
-     Multiaddress [Bytes]
+     ID Bytes
+     Addrs [Bytes]
 }
 
 # XXX: can we have a union representation that tries to parse in order of rules?


### PR DESCRIPTION
Here's the difference between the current [`findProvidersAsync`](https://github.com/libp2p/go-libp2p-core/blob/master/routing/routing.go#L36) and the StoreTheIndex v0 [`finder`](https://github.com/filecoin-project/storetheindex/tree/main/api/v0/finder) structures.