### PR TITLE
ci: add check to ensure generated files are up-to-date

### DIFF
--- a/.github/workflows/go-check-config.json
+++ b/.github/workflows/go-check-config.json
@@ -1,0 +1,3 @@
+{
+    "gogenerate": true
+}

--- a/gen/routing.go
+++ b/gen/routing.go
@@ -245,7 +245,8 @@ func main() {
 		logger.Errorf("compilation (%v)\n", err)
 		os.Exit(-1)
 	}
-	if err = os.Mkdir(dir, 0755); err != nil {
+	// use MkdirAll since it doesn't return an err if the dir already exists
+	if err = os.MkdirAll(dir, 0755); err != nil {
 		logger.Errorf("making pkg dir (%v)\n", err)
 		os.Exit(-1)
 	}


### PR DESCRIPTION
The tests for this should fail, because the generated code is out-of-date. I'll follow up with a fix for that, but it's useful for it to fail here, to demonstrate that it works.