### PR TITLE
feat: use GET for FindProviders

### DIFF
--- a/gen/routing.go
+++ b/gen/routing.go
@@ -24,6 +24,7 @@ var proto = defs.Defs{
 						Arg:    defs.Ref{Name: "FindProvidersRequest"},
 						Return: defs.Ref{Name: "FindProvidersResponse"},
 					},
+					Cachable: true,
 				},
 				defs.Method{
 					Name: "GetIPNS",

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ipfs/go-cid v0.2.0
 	github.com/ipfs/go-ipns v0.1.2
 	github.com/ipfs/go-log/v2 v2.5.1
-	github.com/ipld/edelweiss v0.1.6
+	github.com/ipld/edelweiss v0.2.0
 	github.com/ipld/go-ipld-prime v0.17.1-0.20220627233435-adf99676901e
 	github.com/libp2p/go-libp2p-core v0.16.1
 	github.com/libp2p/go-libp2p-record v0.1.3

--- a/go.sum
+++ b/go.sum
@@ -98,8 +98,8 @@ github.com/ipfs/go-log/v2 v2.0.5/go.mod h1:eZs4Xt4ZUJQFM3DlanGhy7TkwwawCZcSByscw
 github.com/ipfs/go-log/v2 v2.1.3/go.mod h1:/8d0SH3Su5Ooc31QlL1WysJhvyOTDCjcCZ9Axpmri6g=
 github.com/ipfs/go-log/v2 v2.5.1 h1:1XdUzF7048prq4aBjDQQ4SL5RxftpRGdXhNRwKSAlcY=
 github.com/ipfs/go-log/v2 v2.5.1/go.mod h1:prSpmC1Gpllc9UYWxDiZDreBYw7zp4Iqp1kOLU9U5UI=
-github.com/ipld/edelweiss v0.1.6 h1:LHx4wzsbQYC5UvN+7xwvwnGbq8kCsMbOSbfBYVCC1nY=
-github.com/ipld/edelweiss v0.1.6/go.mod h1:IVSfo5e7vJrTKKRjR1lrtfgc2UbEMvvatNycfH9fRfY=
+github.com/ipld/edelweiss v0.2.0 h1:KfAZBP8eeJtrLxLhi7r3N0cBCo7JmwSRhOJp3WSpNjk=
+github.com/ipld/edelweiss v0.2.0/go.mod h1:FJAzJRCep4iI8FOFlRriN9n0b7OuX3T/S9++NpBDmA4=
 github.com/ipld/go-ipld-prime v0.9.0/go.mod h1:KvBLMr4PX1gWptgkzRjVZCrLmSGcZCb/jioOQwCqZN8=
 github.com/ipld/go-ipld-prime v0.17.0/go.mod h1:aYcKm5TIvGfY8P3QBKz/2gKcLxzJ1zDaD+o0bOowhgs=
 github.com/ipld/go-ipld-prime v0.17.1-0.20220627233435-adf99676901e h1:p5qepdt1UEk6UadNwNBFDlm/uC+GwSmdVB4wqyt2JLA=


### PR DESCRIPTION
This is so the result is cacheable using a CDN, which is required by StoreTheIndex to scale to current traffic levels from Hydra.