### PR TITLE
Fixed the issue with payload serialisation when a multiaddr is present for provider

### DIFF
--- a/client/provide.go
+++ b/client/provide.go
@@ -139,8 +139,8 @@ func bytesToMA(b []byte) (interface{}, error) {
 	return multiaddr.NewMultiaddrBytes(b)
 }
 func maToBytes(iface interface{}) ([]byte, error) {
-	if ma, ok := iface.(multiaddr.Multiaddr); ok {
-		return ma.Bytes(), nil
+	if ma, ok := iface.(*multiaddr.Multiaddr); ok {
+		return (*ma).Bytes(), nil
 	}
 	return nil, fmt.Errorf("did not get expected MA type")
 }

--- a/test/provide_test.go
+++ b/test/provide_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/peer"
 	multiaddr "github.com/multiformats/go-multiaddr"
+	"github.com/multiformats/go-multicodec"
 	"github.com/multiformats/go-multihash"
 )
 
@@ -34,12 +35,17 @@ func TestProvideRoundtrip(t *testing.T) {
 		t.Fatal("should get sync error on unsigned provide request.")
 	}
 
+	ma, err := multiaddr.NewMultiaddr("/ip4/0.0.0.0/tcp/4001")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	c, s := createClientAndServer(t, testDelegatedRoutingService{}, &client.Provider{
 		Peer: peer.AddrInfo{
 			ID:    pID,
-			Addrs: []multiaddr.Multiaddr{},
+			Addrs: []multiaddr.Multiaddr{ma},
 		},
-		ProviderProto: []client.TransferProtocol{},
+		ProviderProto: []client.TransferProtocol{{Codec: multicodec.TransportBitswap}},
 	}, priv)
 	defer s.Close()
 


### PR DESCRIPTION
This PR fixes a bug when a payload fails to serialise if a multiaddr is present for provider