### PR TITLE
Fixed a bug with signature verification check

### DIFF
--- a/client/findproviders.go
+++ b/client/findproviders.go
@@ -142,14 +142,14 @@ func parseProtoNodeToAddrInfo(n proto.Node) []peer.AddrInfo {
 	if n.Peer == nil { // ignore non-peer nodes
 		return nil
 	}
-	infos = append(infos, ParseNodeAddresses(n.Peer)...)
+	infos = append(infos, ParseNodeAddresses(n.Peer))
 	return infos
 }
 
 // ParseNodeAddresses parses peer node addresses from the protocol structure Peer.
-func ParseNodeAddresses(n *proto.Peer) []peer.AddrInfo {
+func ParseNodeAddresses(n *proto.Peer) peer.AddrInfo {
 	peerID := peer.ID(n.ID)
-	infos := []peer.AddrInfo{}
+	info := peer.AddrInfo{ID: peerID}
 	for _, addrBytes := range n.Multiaddresses {
 		ma, err := multiaddr.NewMultiaddrBytes(addrBytes)
 		if err != nil {
@@ -162,12 +162,9 @@ func ParseNodeAddresses(n *proto.Peer) []peer.AddrInfo {
 			logger.Infof("dropping provider multiaddress %v ending in /p2p/peerid", ma)
 			continue
 		}
-		infos = append(infos, peer.AddrInfo{ID: peerID, Addrs: []multiaddr.Multiaddr{ma}})
+		info.Addrs = append(info.Addrs, ma)
 	}
-	if len(n.Multiaddresses) == 0 {
-		infos = append(infos, peer.AddrInfo{ID: peerID})
-	}
-	return infos
+	return info
 }
 
 // ToProtoPeer creates a protocol Peer structure from address info.

--- a/test/provide_test.go
+++ b/test/provide_test.go
@@ -35,7 +35,12 @@ func TestProvideRoundtrip(t *testing.T) {
 		t.Fatal("should get sync error on unsigned provide request.")
 	}
 
-	ma, err := multiaddr.NewMultiaddr("/ip4/0.0.0.0/tcp/4001")
+	ma1, err := multiaddr.NewMultiaddr("/ip4/0.0.0.0/tcp/4001")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ma2, err := multiaddr.NewMultiaddr("/ip4/0.0.0.0/tcp/4002")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -43,7 +48,7 @@ func TestProvideRoundtrip(t *testing.T) {
 	c, s := createClientAndServer(t, testDelegatedRoutingService{}, &client.Provider{
 		Peer: peer.AddrInfo{
 			ID:    pID,
-			Addrs: []multiaddr.Multiaddr{ma},
+			Addrs: []multiaddr.Multiaddr{ma1, ma2},
 		},
 		ProviderProto: []client.TransferProtocol{{Codec: multicodec.TransportBitswap}},
 	}, priv)


### PR DESCRIPTION
This PR fixes a bug when server signature verification fails when a Peer has more than one multiaddress